### PR TITLE
remove markdown from non-markdown file

### DIFF
--- a/exercises/.keep
+++ b/exercises/.keep
@@ -1,2 +1,0 @@
-As of [issue 3336](https://github.com/exercism/exercism.io/issues/3336),
-all exercises should go into the exercises directory.


### PR DESCRIPTION
This was my fault, I renamed NOTE.md and didn't take out the markdown.