### PR TITLE
Rename the global exercise hints file

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,6 +9,7 @@
   ],
   "ignored": [
     "bin",
+    "docs",
     "img"
   ],
   "foregone": [


### PR DESCRIPTION
We've had some difficulty coming up with a good name for the file
that gets included in all of the exercise READMEs for a given track.

These are global hints, like how to run the test suite, which are
relevant to all the exercises on a track.

We started with SETUP.md in the root of the repository, then renamed
that to exercises/TRACK_HINTS.md because SETUP.md was misleading and
confusing, but then we realized that TRACK_HINTS.md was a bit ambiguous
and confusing as well.

Finally we settled on putting the file in the docs directory, since
this is user-facing documentation, and calling the file
EXERCISE_README_INSERT.md

See https://github.com/exercism/meta/issues/5 for context.